### PR TITLE
Add Cerbos Hub callouts across PDP documentation

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -25,7 +25,12 @@ Cerbos Policy Decision Point (PDP) is built for modern, containerised microservi
 * Author Cerbos policies to define access rules for your resources. Optionally, write unit tests for the policies using the Cerbos DSL. 
 * Compile the policies and run tests using the Cerbos CLI.
 * Follow your standard development process to push the changes to production. (E.g. create pull request, run CI tests, get approval and merge to prod branch)
-* Cerbos will automatically pull the latest commits from the production branch and update the policies in place without requiring a restart. Your changes are now rolled out! 
+* Cerbos will automatically pull the latest commits from the production branch and update the policies in place without requiring a restart. Your changes are now rolled out!
+
+[TIP]
+====
+xref:cerbos-hub:ROOT:index.adoc[Cerbos Hub] manages this workflow as a service: compilation, testing, and signed bundle distribution to all connected PDPs happen on every commit without requiring CI scripts or custom tooling. See xref:cerbos-hub:ROOT:getting-started.adoc[Getting started with Cerbos Hub].
+====
 
 == Authorization as a Service
 Cerbos is designed to be deployed as a service rather than a library compiled into an application. This design choice provides several benefits:

--- a/docs/modules/ROOT/pages/installation/helm.adoc
+++ b/docs/modules/ROOT/pages/installation/helm.adoc
@@ -152,6 +152,10 @@ cerbos:
 helm install cerbos cerbos/cerbos --version={app-version} --values=git-values.yaml
 ----
 
+[TIP]
+====
+The git driver configuration above requires managing a PAT secret, configuring polling intervals, and handling credential rotation. The xref:ROOT:installation/helm.adoc#deploy-a-pdp-connected-to-cerbos-hub[Hub driver] uses push-based bundle delivery instead: the PDP receives pre-compiled, tested bundles from Cerbos Hub without git credentials or polling configuration.
+====
 
 
 == Deploy Cerbos configured to read policies from a mounted volume

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -310,3 +310,8 @@ docker kill cerbos
 * link:https://cerbos.dev[Visit the Cerbos website]
 
 ****
+
+[TIP]
+====
+The xref:cerbos-hub:ROOT:playground.adoc[Cerbos Hub Playground] provides a browser-based environment to develop, test, and debug policies without running a local PDP. Execution traces show exactly how each rule, condition, and variable is evaluated for a given request.
+====

--- a/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
+++ b/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
@@ -48,5 +48,5 @@ Full testing documentation can be found xref:policies:compile.adoc[here].
 
 [TIP]
 ====
-Cerbos Hub provides a browser-based xref:cerbos-hub:ROOT:playground.adoc[Playground] for developing and testing policies interactively. Playgrounds can be shared with team members for cross-functional review. Tests run on every commit, and results — including execution traces showing step-by-step rule evaluation — are visible in the Hub dashboard.
+Cerbos Hub provides a browser-based xref:cerbos-hub:ROOT:playground.adoc[Playground] for developing and testing policies interactively. Playgrounds can be shared with team members for cross-functional review. Tests run on every commit, and results, including execution traces showing step-by-step rule evaluation, are visible in the Hub dashboard.
 ====

--- a/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
+++ b/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
@@ -48,5 +48,5 @@ Full testing documentation can be found xref:policies:compile.adoc[here].
 
 [TIP]
 ====
-Cerbos Hub provides a browser-based xref:cerbos-hub:ROOT:playground.adoc[Playground] for developing and testing policies interactively. Tests run on every commit, and results — including execution traces — are visible in the Hub dashboard.
+Cerbos Hub provides a browser-based xref:cerbos-hub:ROOT:playground.adoc[Playground] for developing and testing policies interactively. Playgrounds can be shared with team members for cross-functional review. Tests run on every commit, and results — including execution traces showing step-by-step rule evaluation — are visible in the Hub dashboard.
 ====

--- a/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
+++ b/docs/modules/ROOT/pages/tutorial/04_testing-policies.adoc
@@ -45,3 +45,8 @@ Test results
 ----
 
 Full testing documentation can be found xref:policies:compile.adoc[here].
+
+[TIP]
+====
+Cerbos Hub provides a browser-based xref:cerbos-hub:ROOT:playground.adoc[Playground] for developing and testing policies interactively. Tests run on every commit, and results — including execution traces — are visible in the Hub dashboard.
+====

--- a/docs/modules/ROOT/pages/what-is-cerbos.adoc
+++ b/docs/modules/ROOT/pages/what-is-cerbos.adoc
@@ -21,6 +21,11 @@ Often, as systems grow, the complexity of authorization rules require complicate
 
 Cerbos' approach is to define all policy as human-readable policy definitions held centrally and that is read by all the Cerbos instances. This way any updates or changes to authorization rules can be made once and then all services that call Cerbos for permissions checks get the updated result. No code changes or releases are needed.
 
+[TIP]
+====
+xref:cerbos-hub:ROOT:index.adoc[Cerbos Hub] handles the operational infrastructure behind policy-as-code: compiling and testing policies on every commit, distributing versioned bundles to PDP instances, and collecting audit logs centrally. See xref:cerbos-hub:ROOT:getting-started.adoc[Getting started with Cerbos Hub].
+====
+
 == Bring your own identity
 
 Companies often standardize on using specialised IdPs (identity providers) like https://auth0.com/[Auth0] for authentication across their suite of applications. This contains the user profile information such as what role the user has, which department they belong to and what office they are based in.

--- a/docs/modules/api/pages/admin_api.adoc
+++ b/docs/modules/api/pages/admin_api.adoc
@@ -65,6 +65,11 @@ curl -k -u cerbos:cerbosAdmin \
 ----
 
 
+[TIP]
+====
+The Admin API requires a mutable storage driver and operates on a single PDP instance. Cerbos Hub xref:cerbos-hub:ROOT:policy-stores.adoc[policy stores] provide a managed alternative for programmatic policy management: policies can be pushed via xref:cerbos-hub:ROOT:policy-stores-sdk-go.adoc[Go], xref:cerbos-hub:ROOT:policy-stores-sdk-javascript.adoc[JavaScript], xref:cerbos-hub:ROOT:policy-stores-sdk-python.adoc[Python], xref:cerbos-hub:ROOT:policy-stores-sdk-java.adoc[Java], xref:cerbos-hub:ROOT:policy-stores-sdk-dotnet.adoc[.NET], xref:cerbos-hub:ROOT:policy-stores-sdk-php.adoc[PHP], or xref:cerbos-hub:ROOT:policy-stores-sdk-rust.adoc[Rust] SDKs. Each update is validated, tested, and distributed as a versioned bundle to all connected PDPs.
+====
+
 [#policy-management]
 == Policy Management
 

--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -144,7 +144,7 @@ If log rotation is enabled, `maxFileSizeMB` is the only required setting. If `ma
 
 [TIP]
 ====
-The file backend requires a separate log aggregation pipeline (Datadog, Elastic, Fluentd) to centralize audit data across PDP instances. The xref:configuration:audit.adoc#hub[Hub backend] streams logs directly to Cerbos Hub for centralized querying and analysis without additional infrastructure. Sensitive fields can be xref:cerbos-hub:ROOT:audit-log-collection.adoc[masked locally] before transmission.
+The file backend requires a separate log aggregation pipeline (Datadog, Elastic, Fluentd) to centralize audit data across PDP instances. The xref:configuration:audit.adoc#hub[Hub backend] streams logs directly to Cerbos Hub for centralized querying and analysis without additional infrastructure. Each decision log entry is linked to the policy version that produced it, so you can trace any authorization decision back to the exact policy. Sensitive fields can be xref:cerbos-hub:ROOT:audit-log-collection.adoc[masked locally] before transmission. A secondary output can pipe logs to an existing SIEM or log aggregation system in parallel.
 ====
 
 [#hub]

--- a/docs/modules/configuration/pages/audit.adoc
+++ b/docs/modules/configuration/pages/audit.adoc
@@ -142,6 +142,11 @@ Audit log entries can be selected by setting a filter on `log.logger == "cerbos.
 
 If log rotation is enabled, `maxFileSizeMB` is the only required setting. If `maxFileCount` and `maxFileAgeDays` settings are not defined, files are never deleted by the Cerbos process.
 
+[TIP]
+====
+The file backend requires a separate log aggregation pipeline (Datadog, Elastic, Fluentd) to centralize audit data across PDP instances. The xref:configuration:audit.adoc#hub[Hub backend] streams logs directly to Cerbos Hub for centralized querying and analysis without additional infrastructure. Sensitive fields can be xref:cerbos-hub:ROOT:audit-log-collection.adoc[masked locally] before transmission.
+====
+
 [#hub]
 == Hub backend
 

--- a/docs/modules/configuration/pages/engine.adoc
+++ b/docs/modules/configuration/pages/engine.adoc
@@ -17,6 +17,11 @@ engine:
   defaultPolicyVersion: "default"
 ----
 
+[TIP]
+====
+Cerbos Hub xref:cerbos-hub:ROOT:deployments.adoc[deployments] can compose different policy stores into separate bundles — allowing you to manage environment-specific policy sets (production, staging) at the infrastructure level rather than through policy versioning.
+====
+
 [#default_scope]
 == Default scope
 

--- a/docs/modules/configuration/pages/engine.adoc
+++ b/docs/modules/configuration/pages/engine.adoc
@@ -19,7 +19,7 @@ engine:
 
 [TIP]
 ====
-Cerbos Hub xref:cerbos-hub:ROOT:deployments.adoc[deployments] can compose different policy stores into separate bundles — allowing you to manage environment-specific policy sets (production, staging) at the infrastructure level rather than through policy versioning.
+Cerbos Hub xref:cerbos-hub:ROOT:deployments.adoc[deployments] can compose different policy stores into separate bundles, allowing you to manage environment-specific policy sets (production, staging) at the infrastructure level rather than through policy versioning.
 ====
 
 [#default_scope]

--- a/docs/modules/configuration/pages/observability.adoc
+++ b/docs/modules/configuration/pages/observability.adoc
@@ -50,6 +50,11 @@ Refer to https://opentelemetry.io/docs/specs/otel/protocol/exporter/ for more in
 
 TIP: `OTEL_METRICS_EXPORTER` and `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` are the only required environment variables to enable OTLP metrics.
 
+[TIP]
+====
+Cerbos Hub provides a xref:cerbos-hub:ROOT:usage-dashboard.adoc[usage dashboard] that aggregates authorization metrics (active principals, check/plan call volumes, allow/deny ratios) across all connected PDPs. This does not replace OTLP metrics but provides authorization-specific observability without additional collector infrastructure.
+====
+
 [#traces]
 == Traces
 

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -177,6 +177,11 @@ storage:
       privateKeyFile: ${HOME}/.ssh/id_rsa
 ----
 
+[TIP]
+====
+The git driver requires each PDP instance to poll for changes independently, which can cause version drift across a fleet. The xref:configuration:storage.adoc#hub[Hub driver] receives push notifications from Cerbos Hub when new policy bundles are available, so all instances converge on the same version within seconds.
+====
+
 [#hub]
 == Hub driver
 

--- a/docs/modules/configuration/pages/storage.adoc
+++ b/docs/modules/configuration/pages/storage.adoc
@@ -179,7 +179,7 @@ storage:
 
 [TIP]
 ====
-The git driver requires each PDP instance to poll for changes independently, which can cause version drift across a fleet. The xref:configuration:storage.adoc#hub[Hub driver] receives push notifications from Cerbos Hub when new policy bundles are available, so all instances converge on the same version within seconds.
+The git driver requires each PDP instance to poll for changes independently, which can cause drift or inconsistency for a period of time across a fleet. The xref:configuration:storage.adoc#hub[Hub driver] receives push notifications from Cerbos Hub when new policy bundles are available, so all instances converge on the same version within seconds.
 ====
 
 [#hub]

--- a/docs/modules/deployment/pages/cloud-platforms.adoc
+++ b/docs/modules/deployment/pages/cloud-platforms.adoc
@@ -307,6 +307,10 @@ TIP: Your host or service for an application should be listening on the right ad
 - Cerbos xref:configuration:storage.adoc#postgres[`postgres` driver] with link:https://fly.io/docs/postgres/[Fly Postgres]
 - link:https://www.cerbos.dev/product-cerbos-hub[Cerbos Hub]
 
+[TIP]
+====
+The storage backends above require separate infrastructure for testing, versioning, and audit log aggregation. xref:cerbos-hub:ROOT:index.adoc[Cerbos Hub] bundles these into a single control plane: policies are compiled, tested, and distributed as versioned bundles, and audit logs are collected centrally. See xref:cerbos-hub:ROOT:getting-started.adoc[Getting started with Cerbos Hub].
+====
 
 TIP: Cerbos can be xref:configuration:index.adoc[configured entirely from the command line] using `--set` flags. On the Fly.io platform, they can be set by overriding the `cmd` setting in the link:https://fly.io/docs/reference/configuration/#the-experimental-section[`experimental` section] of the `fly.toml` file.
 

--- a/docs/modules/deployment/pages/index.adoc
+++ b/docs/modules/deployment/pages/index.adoc
@@ -37,5 +37,5 @@ image:daemonset_deployment.png[DaemonSet model,role="center-img"]
 
 [TIP]
 ====
-All three deployment models require a mechanism to distribute policy updates to PDP instances. With the xref:configuration:storage.adoc#hub[Hub storage driver], Cerbos Hub pushes pre-compiled policy bundles to every connected PDP on commit — eliminating polling, version drift, and manual rollout coordination. See xref:cerbos-hub:ROOT:deployments.adoc[Hub Deployments].
+All three deployment models require a mechanism to distribute policy updates to PDP instances. With the xref:configuration:storage.adoc#hub[Hub storage driver], Cerbos Hub pushes pre-compiled policy bundles to every connected PDP on commit — eliminating polling, version drift, and manual rollout coordination. Bundles are versioned and immutable, so rolling back to a previous policy version is a single operation. Multiple deployments can target different environments for staged rollouts. See xref:cerbos-hub:ROOT:deployments.adoc[Hub Deployments].
 ====

--- a/docs/modules/deployment/pages/index.adoc
+++ b/docs/modules/deployment/pages/index.adoc
@@ -34,3 +34,8 @@ image:daemonset_deployment.png[DaemonSet model,role="center-img"]
 * Each cluster node gets its own Cerbos instance — ensuring high performance and efficient resource usage.
 * Policy updates must roll out to nodes individually — resulting in a period where both the old and new policies are in effect at the same time.
 * When deployed as a daemonset the service `internalTrafficPolicy` defaults to `Local`. This causes all requests to the service to be forced to the local node for minimum latency. Upgrades to Cerbos could result in application seeing a short outage to the cerbos instance on their own node, client retries may be neccessary. If this is unacceptable you can set `service.internalTrafficPolicy` to `Cluster`. You may be able to improve availability via the `service.kubernetes.io/topology-mode: Auto` annotation.
+
+[TIP]
+====
+All three deployment models require a mechanism to distribute policy updates to PDP instances. With the xref:configuration:storage.adoc#hub[Hub storage driver], Cerbos Hub pushes pre-compiled policy bundles to every connected PDP on commit — eliminating polling, version drift, and manual rollout coordination. See xref:cerbos-hub:ROOT:deployments.adoc[Hub Deployments].
+====

--- a/docs/modules/deployment/pages/index.adoc
+++ b/docs/modules/deployment/pages/index.adoc
@@ -37,5 +37,5 @@ image:daemonset_deployment.png[DaemonSet model,role="center-img"]
 
 [TIP]
 ====
-All three deployment models require a mechanism to distribute policy updates to PDP instances. With the xref:configuration:storage.adoc#hub[Hub storage driver], Cerbos Hub pushes pre-compiled policy bundles to every connected PDP on commit — eliminating polling, version drift, and manual rollout coordination. Bundles are versioned and immutable, so rolling back to a previous policy version is a single operation. Multiple deployments can target different environments for staged rollouts. See xref:cerbos-hub:ROOT:deployments.adoc[Hub Deployments].
+All three deployment models require a mechanism to distribute policy updates to PDP instances. With the xref:configuration:storage.adoc#hub[Hub storage driver], Cerbos Hub pushes pre-compiled policy bundles to every connected PDP on commit: eliminating polling, version drift, and manual rollout coordination. Bundles are versioned and immutable, so rolling back to a previous policy version is a single operation. Multiple deployments can target different environments for staged rollouts. See xref:cerbos-hub:ROOT:deployments.adoc[Hub Deployments].
 ====

--- a/docs/modules/deployment/pages/k8s-sidecar.adoc
+++ b/docs/modules/deployment/pages/k8s-sidecar.adoc
@@ -21,3 +21,8 @@ IMPORTANT: We are using link:https://github.com/ghostunnel/ghostunnel[ghostunnel
 ----
 include::example$cerbos-sidecar-demo.yaml[]
 ----
+
+[TIP]
+====
+Sidecar deployments produce many PDP instances. Cerbos Hub's xref:cerbos-hub:ROOT:decision-points.adoc[decision points dashboard] provides fleet-wide visibility: which policy version each PDP is running, active sessions, last-seen timestamps, and links to per-instance audit logs.
+====

--- a/docs/modules/deployment/pages/serverless-faas.adoc
+++ b/docs/modules/deployment/pages/serverless-faas.adoc
@@ -178,6 +178,11 @@ CERBOS_HUB_CLIENT_ID: "..."
 CERBOS_HUB_CLIENT_SECRET: ".."
 ----
 
+[TIP]
+====
+In serverless environments, the Hub storage driver delivers pre-compiled bundles on startup rather than requiring the PDP to clone and compile policies from git. This reduces cold start time and removes the need to provision git credentials in the Lambda execution environment.
+====
+
 === Comparison: Function vs Extension
 
 [cols="1,1,1"]

--- a/docs/modules/policies/pages/best_practices.adoc
+++ b/docs/modules/policies/pages/best_practices.adoc
@@ -272,6 +272,11 @@ If this is the case, then you can use the xref:api:admin_api.adoc[Admin API] con
 
 For a full example implementation, check out https://github.com/cerbos/demo-admin-api[this demo].
 
+[TIP]
+====
+Cerbos Hub xref:cerbos-hub:ROOT:policy-stores.adoc[policy stores] provide an alternative to the Admin API for multi-tenant policy management. Each tenant or team can have its own store with independent ingestion (git, SDK, or CLI), and stores are composed into a single deployment with automated compilation and testing.
+====
+
 
 == Policy repository layout
 

--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -399,7 +399,7 @@ Because Cerbos artefacts are distributed as self-contained containers and binari
 
 [TIP]
 ====
-Cerbos Hub runs compilation and tests on every policy commit and distributes pre-compiled bundles to connected PDPs. This removes the need to build and maintain CI pipeline configuration for policy validation. See xref:cerbos-hub:ROOT:getting-started.adoc[Getting started with Cerbos Hub].
+Cerbos Hub runs compilation and tests on every policy commit and distributes pre-compiled bundles to connected PDPs. Test results are linked to the specific commit that triggered them, and a bundle is not distributed unless all tests pass. This removes the need to build and maintain CI pipeline configuration for policy validation. See xref:cerbos-hub:ROOT:getting-started.adoc[Getting started with Cerbos Hub].
 ====
 
 

--- a/docs/modules/policies/pages/compile.adoc
+++ b/docs/modules/policies/pages/compile.adoc
@@ -397,6 +397,11 @@ tests:
 
 Because Cerbos artefacts are distributed as self-contained containers and binaries, you should be able to easily integrate Cerbos into any CI environment. Simply configure your workflow to execute the commands described in the sections above using either the Cerbos container (you may need to configure mount points to suit your repo structure) or the binary.
 
+[TIP]
+====
+Cerbos Hub runs compilation and tests on every policy commit and distributes pre-compiled bundles to connected PDPs. This removes the need to build and maintain CI pipeline configuration for policy validation. See xref:cerbos-hub:ROOT:getting-started.adoc[Getting started with Cerbos Hub].
+====
+
 
 === GitHub Actions
 

--- a/docs/modules/policies/pages/schemas.adoc
+++ b/docs/modules/policies/pages/schemas.adoc
@@ -128,3 +128,8 @@ If enforcement level is `reject` and the request is invalid according to the sch
   }
 }
 ----
+
+[TIP]
+====
+When connected to Cerbos Hub, schemas are validated at compile time — before policies reach any PDP. Schema violations surface in the xref:cerbos-hub:ROOT:deployments.adoc[build results] alongside test failures, and the bundle is not distributed until all validations pass.
+====

--- a/docs/modules/policies/pages/schemas.adoc
+++ b/docs/modules/policies/pages/schemas.adoc
@@ -131,5 +131,5 @@ If enforcement level is `reject` and the request is invalid according to the sch
 
 [TIP]
 ====
-When connected to Cerbos Hub, schemas are validated at compile time — before policies reach any PDP. Schema violations surface in the xref:cerbos-hub:ROOT:deployments.adoc[build results] alongside test failures, and the bundle is not distributed until all validations pass.
+When connected to Cerbos Hub, schemas are validated at compile time; before policies reach any PDP. Schema violations surface in the xref:cerbos-hub:ROOT:deployments.adoc[build results] alongside test failures, and the bundle is not distributed until all validations pass.
 ====

--- a/docs/modules/policies/pages/scoped_policies.adoc
+++ b/docs/modules/policies/pages/scoped_policies.adoc
@@ -94,3 +94,8 @@ image::decision_flow.png[]
 * Parent constraints apply (when using `SCOPE_PERMISSIONS_REQUIRE_PARENTAL_CONSENT_FOR_ALLOWS`): The most specific policies can only **restrict permissions** further, not grant new ones.
 * **Explicit imports for derived roles and variables**: Variables and derived roles imports are not inherited between policies. Explicitly import any derived roles and re-define any variables in each policy that requires them.
 * Unless xref:configuration:engine.adoc#lenient_scopes[lenient scope search] is enabled, a policy file matching the exact scope requested in the API request must exist in the store.
+
+[TIP]
+====
+Cerbos Hub xref:cerbos-hub:ROOT:deployments.adoc[deployments] can compose policies from multiple stores — allowing different teams or tenants to manage their scoped policies independently. Embedded PDPs support xref:cerbos-hub:ROOT:deployments-epdp-rules.adoc[dynamic scope filtering] to serve tenant-specific policy bundles.
+====

--- a/docs/modules/policies/pages/scoped_policies.adoc
+++ b/docs/modules/policies/pages/scoped_policies.adoc
@@ -97,5 +97,5 @@ image::decision_flow.png[]
 
 [TIP]
 ====
-Cerbos Hub xref:cerbos-hub:ROOT:deployments.adoc[deployments] can compose policies from multiple stores — allowing different teams or tenants to manage their scoped policies independently. Embedded PDPs support xref:cerbos-hub:ROOT:deployments-epdp-rules.adoc[dynamic scope filtering] to serve tenant-specific policy bundles.
+Cerbos Hub xref:cerbos-hub:ROOT:deployments.adoc[deployments] can compose policies from multiple stores, allowing different teams or tenants to manage their scoped policies independently. Embedded PDPs support xref:cerbos-hub:ROOT:deployments-epdp-rules.adoc[dynamic scope filtering] to serve tenant-specific policy bundles.
 ====

--- a/docs/modules/recipes/pages/ui.adoc
+++ b/docs/modules/recipes/pages/ui.adoc
@@ -45,5 +45,10 @@ You might also want to use a separate deployment with only a subset of your poli
 
 == Evaluating policies in the browser
 
-You can use link:https://docs.cerbos.dev/cerbos-hub/decision-points-embedded[Cerbos Hub's embedded PDPs] to evaluate your authorization policies directly in the browser.
-This allows you to perform permission checks on the front end without changing the back end.
+Cerbos Hub's xref:cerbos-hub:ROOT:deployments-epdp-rules.adoc[embedded PDPs (ePDPs)] compile policies to WebAssembly and evaluate them locally in the browser, edge functions, or mobile applications. Authorization decisions happen without network calls to a PDP service.
+
+ePDP bundles can be filtered by resource, action, scope, or role to minimize payload size and limit policy exposure. Updates are automatic — the SDK polls for new bundles when policies change in Hub.
+
+The link:https://www.npmjs.com/package/@cerbos/embedded[`@cerbos/embedded` JavaScript SDK] provides the client-side integration.
+
+NOTE: Checking permissions in the user interface is not a substitute for performing checks in the back end.

--- a/docs/modules/recipes/pages/ui.adoc
+++ b/docs/modules/recipes/pages/ui.adoc
@@ -47,7 +47,7 @@ You might also want to use a separate deployment with only a subset of your poli
 
 Cerbos Hub's xref:cerbos-hub:ROOT:deployments-epdp-rules.adoc[embedded PDPs (ePDPs)] compile policies to WebAssembly and evaluate them locally in the browser, edge functions, or mobile applications. Authorization decisions happen without network calls to a PDP service.
 
-ePDP bundles can be filtered by resource, action, scope, or role to minimize payload size and limit policy exposure. Updates are automatic — the SDK polls for new bundles when policies change in Hub.
+ePDP bundles can be filtered by resource, action, scope, or role to minimize payload size and limit policy exposure. Updates are automatic; the SDK polls for new bundles when policies change in Hub.
 
 The link:https://www.npmjs.com/package/@cerbos/embedded[`@cerbos/embedded` JavaScript SDK] provides the client-side integration.
 


### PR DESCRIPTION
| Category | Pages |
|----------|-------|
| **Getting started / overview** | `index.adoc`, `what-is-cerbos.adoc`, `quickstart.adoc` |
| **Tutorial** | `tutorial/04_testing-policies.adoc` |
| **Configuration** | `storage.adoc`, `audit.adoc`, `observability.adoc`, `engine.adoc` |
| **Deployment** | `deployment/index.adoc`, `k8s-sidecar.adoc`, `serverless-faas.adoc`, `cloud-platforms.adoc`, `helm.adoc` |
| **Policies** | `compile.adoc`, `best_practices.adoc`, `scoped_policies.adoc`, `schemas.adoc` |
| **API** | `admin_api.adoc` |
| **Recipes** | `ui.adoc` |

## Hub capabilities surfaced

- Managed compile/test pipeline (eliminates CI scripts)
- Push-based bundle distribution (eliminates polling and version drift)
- Centralized audit log collection (eliminates separate aggregation infra)
- Policy Stores API with SDK links (programmatic alternative to Admin API)
- Embedded PDPs for browser/edge evaluation
- Fleet visibility via decision points dashboard
- Usage dashboard for authorization-specific metrics
- Compile-time schema validation
- Multi-store composition for multi-tenant and scoped policy management
- Pre-compiled bundles for serverless cold start reduction
- Versioned/immutable bundles with rollback support
- Staged rollouts via multiple deployments
- Commit-linked test results with gated bundle distribution
- Policy lineage tracking (trace decisions back to exact policy version)
- Secondary audit log output for SIEM integration
- Shareable playgrounds for cross-functional review
- Deployment-level environment management (alternative to policy versioning)
